### PR TITLE
Refactor from getRouteCollection to generate and match to improve performance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": ">=7.2.5",
         "symfony/dependency-injection": "^4.1.12|^5.0",
         "symfony/config": "~4.4|~5.0",
         "doctrine/annotations": "^1.6",

--- a/src/ParametersProcessor/Factory/EncodeParametersProcessorFactory.php
+++ b/src/ParametersProcessor/Factory/EncodeParametersProcessorFactory.php
@@ -9,7 +9,6 @@ use Pgs\HashIdBundle\AnnotationProvider\AnnotationProvider;
 use Pgs\HashIdBundle\Exception\InvalidControllerException;
 use Pgs\HashIdBundle\Exception\MissingClassOrMethodException;
 use Pgs\HashIdBundle\ParametersProcessor\ParametersProcessorInterface;
-use Symfony\Component\Routing\Route;
 
 class EncodeParametersProcessorFactory extends AbstractParametersProcessorFactory
 {
@@ -27,9 +26,8 @@ class EncodeParametersProcessorFactory extends AbstractParametersProcessorFactor
         $this->encodeParametersProcessor = $encodeParametersProcessor;
     }
 
-    public function createRouteEncodeParametersProcessor(Route $route)
+    public function createRouteEncodeParametersProcessor(string $controller)
     {
-        $controller = $route->getDefault('_controller');
         try {
             /** @var Hash $annotation */
             $annotation = $this->getAnnotationProvider()->getFromString($controller, Hash::class);

--- a/tests/AnnotationProvider/AnnotationProviderTest.php
+++ b/tests/AnnotationProvider/AnnotationProviderTest.php
@@ -18,7 +18,7 @@ class AnnotationProviderTest extends TestCase
      */
     protected $controllerAnnotationProvider;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->controllerAnnotationProvider = new AnnotationProvider(
             $this->getReaderMock(),

--- a/tests/Decorator/RouterDecoratorTest.php
+++ b/tests/Decorator/RouterDecoratorTest.php
@@ -18,7 +18,7 @@ class RouterDecoratorTest extends WebTestCase
      */
     protected static $container;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this::$container = static::createClient()->getContainer();
         $this->router = self::$container->get('router');

--- a/tests/DependencyInjection/Compiler/EventSubscriberCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/EventSubscriberCompilerPassTest.php
@@ -30,7 +30,7 @@ class EventSubscriberCompilerPassTest extends TestCase
      */
     private $decodeControllerParametersDefinition;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->pass = new EventSubscriberCompilerPass();
         $this->container = new ContainerBuilder();

--- a/tests/DependencyInjection/Compiler/HashidsConverterCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/HashidsConverterCompilerPassTest.php
@@ -20,7 +20,7 @@ class HashidsConverterCompilerPassTest extends TestCase
      */
     private $container;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->compilerPass = new HashidsConverterCompilerPass();
 

--- a/tests/ParametersProcessor/Factory/ParametersProcessorFactoryTest.php
+++ b/tests/ParametersProcessor/Factory/ParametersProcessorFactoryTest.php
@@ -18,7 +18,7 @@ abstract class ParametersProcessorFactoryTest extends TestCase
 
     protected $parametersProcessorMockProvider;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->controllerMockProvider = new ControllerMockProvider();
         $this->controllerAnnotationMockProvider = new ControllerAnnotationProviderMockProvider();

--- a/tests/ParametersProcessor/NoOpTest.php
+++ b/tests/ParametersProcessor/NoOpTest.php
@@ -14,7 +14,7 @@ class NoOpTest extends TestCase
      */
     protected $parametersProcessor;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->parametersProcessor = new NoOp($this->getHashidMock(), []);
     }

--- a/tests/Service/DecodeControllerParametersTest.php
+++ b/tests/Service/DecodeControllerParametersTest.php
@@ -20,7 +20,7 @@ class DecodeControllerParametersTest extends TestCase
 
     protected $parametersProcessorMockProvider;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->parametersProcessorMockProvider = new ParametersProcessorMockProvider();
     }

--- a/tests/Traits/DecoratorTraitTest.php
+++ b/tests/Traits/DecoratorTraitTest.php
@@ -10,7 +10,7 @@ class DecoratorTraitTest extends TestCase
 {
     protected $decorateClass;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $baseClass = new BaseTestClass();
         $this->decorateClass = new DecorateTestClass($baseClass);


### PR DESCRIPTION
Use of `getRouteCollection` is a known performance issue:

* https://github.com/symfony/symfony-docs/issues/6710
* https://symfony.com/doc/current/routing.html#checking-if-a-route-exists

Discovered with Blackfire.io: Symfony's route cache gets rebuilt for every request when `pgs-soft/hashid-bundle` is installed.

This should leave the cache intact.